### PR TITLE
Add query command for field-based device search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Quickstart
 - Run the CLI: `uv run ndb`
 - Show version: `uv run ndb -- --version`
 
+Query
+
+- Search devices by field value:
+  - `uv run -- ndb query ip_address=192.168.0.49`
+  - `uv run -- ndb query category=cp --json`
+
 Discovery
 
 - Single device (via /cp/version.json):

--- a/devlog/2025-08-31-query.md
+++ b/devlog/2025-08-31-query.md
@@ -1,0 +1,20 @@
+# 2025-08-31 query devices by example
+
+## Goal
+
+Add `ndb query` to search devices by field values.
+
+## Status
+
+(status helper unavailable)
+
+## Implementation
+
+- Added `query_devices` helper in `db.py`.
+- Introduced `ndb query` CLI for field-based searches with table or JSON output.
+- Documented usage in `README`.
+
+## Demo
+
+- `uv run -- ndb query ip_address=192.168.0.49`
+- `uv run -- ndb query category=cp --json`


### PR DESCRIPTION
## Summary
- add `query_devices` helper to filter devices by column values
- support `ndb query field=value` with table or JSON output
- document query usage in README and devlog

## Testing
- `uv run -- python --version`
- `uv run -- ndb db init`
- `uv run -- ndb put --uid test1 --hostname foo --ip-address 192.168.0.49 --category cp --text '{}'`
- `uv run -- ndb query ip_address=192.168.0.49`
- `uv run -- ndb query category=cp --json`
- `uv run -- python -m pytest` *(fails: No module named pytest)*
- `uvx pytest` *(fails: Failed to fetch from pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_68b44b9c42948333bc6b0dc9494a1162